### PR TITLE
Fix timer undoing AirlineToggle

### DIFF
--- a/autoload/airline/extensions/clock.vim
+++ b/autoload/airline/extensions/clock.vim
@@ -53,3 +53,7 @@ endfunction
 let g:airline#extensions#clock#timer = timer_start(
       \ g:airline#extensions#clock#updatetime,
       \ 'airline#extensions#clock#timerfn',{'repeat':-1})
+
+" Pause the timer when Airline is disabled, un-pause when it's re-enabled
+autocmd User AirlineToggledOff call timer_pause(g:airline#extensions#clock#timer, 1)
+autocmd User AirlineToggledOn call timer_pause(g:airline#extensions#clock#timer, 0)


### PR DESCRIPTION
The timer would automatically re-enable the statusline when Airline is
toggled off (e.g., when using Goyo: junegunn/goyo.vim#214). Pausing the
timer fixes this.