### PR TITLE
incsearch_fix

### DIFF
--- a/autoload/airline/extensions/clock.vim
+++ b/autoload/airline/extensions/clock.vim
@@ -47,7 +47,9 @@ if v:version < 800
 endif
 
 function! airline#extensions#clock#timerfn(timer)
-  call airline#update_statusline()
+  if mode() !~? "c"
+    call airline#update_statusline()
+  endif
 endfunction
 
 let g:airline#extensions#clock#timer = timer_start(

--- a/autoload/airline/extensions/clock.vim
+++ b/autoload/airline/extensions/clock.vim
@@ -47,7 +47,7 @@ if v:version < 800
 endif
 
 function! airline#extensions#clock#timerfn(timer)
-  if mode() !~? "c"
+  if mode() !=? "c" && g:airline_mode_map.multi !=? w:airline_current_mode
     call airline#update_statusline()
   endif
 endfunction


### PR DESCRIPTION
Stop refreshing the clock when in Cmdline to avoid losing the highlight of the line where the cursor is located when real-time search is enabled